### PR TITLE
Update README.md with 2 packs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,5 +11,7 @@ Use this repository to submit issues for the following products:
 * The Red Opera by Apotheosis Studios
 * Sirens - Battle of the Bards by Apotheosis Studios
 * The Demon Queen Awakens by Foundry Virtual Tabletop
+* Atropos Patreon Battlemaps by Foundry Virtual Tabletop
+* Pathfinder Token Pack: Bestiaries
 
 For projects not on this list, issues should be reported somewhere else. Please consult the respective package page on https://foundryvtt.com/packages to find out where.


### PR DESCRIPTION
Left me confused as to where to report a bug for the Pathfinder Token Pack: Bestiaries as it wasn't listed in the README.
Especially with the footer at the bottom stating to look it up on the module browser if it's not listed.